### PR TITLE
Improve examples and fix the result panel size for execution logs

### DIFF
--- a/web/src/components/panels/result-panel.styles.js
+++ b/web/src/components/panels/result-panel.styles.js
@@ -53,7 +53,7 @@ const resultPanelStyle = css`
 
   .result-panel-content {
     overflow: auto;
-    height: 100%;
+    height: calc(100% - 74px);
     border: #eee 1px solid;
     padding-top: 2px;
   }

--- a/web/src/components/playground.js
+++ b/web/src/components/playground.js
@@ -366,11 +366,8 @@ export class Playground extends LitElement {
   _handleConfigExampleChanged(event) {
     let example = event.detail.value;
     if (example) {
-      this.payload = JSON.stringify(
-        JSON.parse(PAYLOAD_EXAMPLES[example.otlp_type]),
-        null,
-        2
-      );
+      let payload = example.payload || PAYLOAD_EXAMPLES[example.otlp_type];
+      this.payload = JSON.stringify(JSON.parse(payload), null, 2);
       this._setSelectedPayloadExample(example.otlp_type);
     }
   }


### PR DESCRIPTION
- Improved and added examples.
- The result panel for execution logs is currently hiding content when the wrap lines is selected. This PR gives it some margin so the overflow is properly displayed.