### PR TITLE
Add component type to telemetry settings

### DIFF
--- a/internal/processorexecutor.go
+++ b/internal/processorexecutor.go
@@ -50,7 +50,7 @@ func newProcessorExecutor[C any](factory processor.Factory) *processorExecutor[C
 	telemetrySettings := componenttest.NewNopTelemetrySettings()
 	telemetrySettings.Logger = logger
 	settings := processor.Settings{
-		ID:                component.MustNewID("ottl_playground"),
+		ID:                component.MustNewIDWithName(factory.Type().String(), "ottl_playground"),
 		TelemetrySettings: telemetrySettings,
 	}
 

--- a/web/src/components/examples.js
+++ b/web/src/components/examples.js
@@ -153,15 +153,6 @@ const TRANSFORM_PROCESSOR_CONFIG_EXAMPLES = [
       '     - copy_metric(name="my.second.histogram") where name == "my.histogram"\n' +
       '     - aggregate_on_attributes("sum", []) where name == "my.second.histogram"',
   },
-  {
-    name: 'Restructure metrics payload',
-    otlp_type: 'metrics',
-    config:
-      'metric_statements:\n' +
-      ' - context: datapoint\n' +
-      '   statements:\n' +
-      '     - merge_maps(resource.attributes, attributes, "upsert") where metric.name == "my.counter"',
-  },
 ];
 
 const FILTER_PROCESSOR_CONFIG_EXAMPLES = [


### PR DESCRIPTION
- The component type is now required and validated in newer collector's versions. 
- Removed duplicate example.