### PR TITLE
Rename diff-based views and fix copy link button when no specific version is selected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY Makefile .
 RUN make build-web
 
 # Web-assembly and server
-FROM golang:1.22 AS wasmbuilder
+FROM golang:1.23 AS wasmbuilder
 WORKDIR /build
 COPY ./ .
 RUN make build-wasm

--- a/web/src/components/panels/result-panel.js
+++ b/web/src/components/panels/result-panel.js
@@ -95,8 +95,8 @@ export class PlaygroundResultPanel extends LitElement {
                                     id="diff-view-select"
                                     .value="${this.view}"
                                     @change="${this._selectedViewChanged}">
-                                <option value="visual_delta">Visual delta</option>
-                                <option value="annotated_delta">Annotated delta</option>
+                                <option value="visual_delta">Visual diff</option>
+                                <option value="annotated_delta">Annotated diff</option>
                                 <option value="json">JSON</option>
                                 <option value="logs">Execution logs</option>
                             </select>

--- a/web/src/components/playground.js
+++ b/web/src/components/playground.js
@@ -126,6 +126,7 @@ export class Playground extends LitElement {
         return response.json();
       })
       .then((json) => {
+        this.version = this.version || json.versions?.[0]?.version;
         this._versions = json.versions;
       });
   }


### PR DESCRIPTION
 - Rename result views `Visual delta` -> `Visual diff`, and `Annotated delta` -> `Annotated diff`.
 - Fixed copy link button when no specific version is selected so the latest version is included on the URL hash.
 - Fixed Dockerfile to use the correct Go's version