### PR TITLE
Enabled lambda feature gates

### DIFF
--- a/internal/feature_gates.go
+++ b/internal/feature_gates.go
@@ -1,0 +1,12 @@
+package internal
+
+import "go.opentelemetry.io/collector/featuregate"
+
+func init() {
+	enableFeatureGates()
+}
+
+func enableFeatureGates() {
+	// OTTL lambda is used across executors.
+	_ = featuregate.GlobalRegistry().Set("ottl.functions.enableLambda", true)
+}


### PR DESCRIPTION
Enables the `ottl.functions.enableLambda` feature gate.